### PR TITLE
Make benchmark scripts compatible with python3

### DIFF
--- a/benchmarks/VRPTW/class_indicators.py
+++ b/benchmarks/VRPTW/class_indicators.py
@@ -69,46 +69,46 @@ def log_indicators(BKS, files):
     computing_times.append(solution['summary']['computing_times']['loading'] + solution['summary']['computing_times']['solving'])
 
   # Output
-  print ',' + ','.join(CLASSES) + ',' + 'Total'
+  print(',' + ','.join(CLASSES) + ',' + 'Total')
 
   cumulated_BKS_CNV = 0
   bks_cnv_line = 'BKS CNV,'
   for c in CLASSES:
     bks_cnv_line += s_round(np.mean(BKS_CNV[c]), 2) + ','
     cumulated_BKS_CNV += sum(BKS_CNV[c])
-  print bks_cnv_line + s_round(cumulated_BKS_CNV, 0)
+  print(bks_cnv_line + s_round(cumulated_BKS_CNV, 0))
 
   cumulated_BKS_CTT = 0
   bks_ctt_line = 'BKS CTT,'
   for c in CLASSES:
     bks_ctt_line += s_round(np.mean(BKS_CTT[c]), 2) + ','
     cumulated_BKS_CTT += sum(BKS_CTT[c])
-  print bks_ctt_line + s_round(cumulated_BKS_CTT, 0)
+  print(bks_ctt_line + s_round(cumulated_BKS_CTT, 0))
 
   cumulated_CNV = 0
   cnv_line = 'CNV,'
   for c in CLASSES:
     cnv_line += s_round(np.mean(CNV[c]), 2) + ','
     cumulated_CNV += sum(CNV[c])
-  print cnv_line + s_round(cumulated_CNV, 0)
+  print(cnv_line + s_round(cumulated_CNV, 0))
 
   cumulated_CTT = 0
   ctt_line = 'CTT,'
   for c in CLASSES:
     ctt_line += s_round(np.mean(CTT[c]) / VRPTW_PRECISION, 2) + ','
     cumulated_CTT += sum(CTT[c])
-  print ctt_line + s_round(cumulated_CTT / VRPTW_PRECISION, 0)
+  print(ctt_line + s_round(cumulated_CTT / VRPTW_PRECISION, 0))
 
   # Computing time percentiles
-  print ','
+  print(',')
   ct_percentiles = np.percentile(computing_times, [0, 10, 25, 50, 75, 90, 100])
-  print ',Computing times'
-  print 'Average,' + s_round(np.mean(computing_times), 0)
-  print ','
+  print(',Computing times')
+  print('Average,' + s_round(np.mean(computing_times), 0))
+  print(',')
 
   titles = ['Min', 'First decile', 'Lower quartile', 'Median', 'Upper quartile', 'Ninth decile', 'Max']
   for i in range(len(titles)):
-    print titles[i] + ',' + s_round(ct_percentiles[i], 0)
+    print(titles[i] + ',' + s_round(ct_percentiles[i], 0))
 
 if __name__ == "__main__":
   # First argument if the best known solution file.

--- a/benchmarks/compare_to_BKS.py
+++ b/benchmarks/compare_to_BKS.py
@@ -25,7 +25,7 @@ def nb_jobs(solution):
   return jobs
 
 def log_comparisons(BKS, files):
-  print ','.join(["Instance", "Jobs", "Vehicles", "tightness", "Best known cost", "Assigned jobs", "Used vehicles", "Solution cost", "Unassigned jobs", "Gap (%)", "Computing time (ms)"])
+  print (','.join(["Instance", "Jobs", "Vehicles", "tightness", "Best known cost", "Assigned jobs", "Used vehicles", "Solution cost", "Unassigned jobs", "Gap (%)", "Computing time (ms)"]))
 
   jobs = []
   vehicles = []
@@ -107,28 +107,28 @@ def log_comparisons(BKS, files):
     line.append(computing_time)
     computing_times.append(computing_time)
 
-    print ','.join(map(lambda x: str(x), line))
+    print(','.join(map(lambda x: str(x), line)))
 
-  print 'Average,' + s_round(np.mean(jobs), 1) + ',' + s_round(np.mean(vehicles), 1) + ',' + s_round(np.mean(tightnesses), 2) + ',' + s_round(np.mean(assigned), 1) + ',,,,' + s_round(np.mean(unassigned), 1) + ',' + s_round(np.mean(gaps), 2) + ',' + s_round(np.mean(computing_times), 0)
+  print('Average,' + s_round(np.mean(jobs), 1) + ',' + s_round(np.mean(vehicles), 1) + ',' + s_round(np.mean(tightnesses), 2) + ',' + s_round(np.mean(assigned), 1) + ',,,,' + s_round(np.mean(unassigned), 1) + ',' + s_round(np.mean(gaps), 2) + ',' + s_round(np.mean(computing_times), 0))
 
   total_jobs = np.sum(jobs)
   assigned_jobs = np.sum(assigned)
-  print ','
-  print 'Total jobs,' + s_round(total_jobs, 0)
-  print 'Total jobs assigned,' + s_round(assigned_jobs, 0) + ',' + s_round(100 * float(assigned_jobs) / total_jobs, 2) + '%'
-  print ','
-  print 'Instances,' + s_round(total_files, 0)
-  print 'All jobs solutions,' + s_round(job_ok_files, 0) + ',' + s_round(100 * float(job_ok_files) / total_files, 2) + '%'
-  print 'Optimal solutions,' + s_round(optimal_sols, 0) + ',' + s_round(100 * float(optimal_sols) / total_files, 2) + '%'
+  print(',')
+  print('Total jobs,' + s_round(total_jobs, 0))
+  print('Total jobs assigned,' + s_round(assigned_jobs, 0) + ',' + s_round(100 * float(assigned_jobs) / total_jobs, 2) + '%')
+  print(',')
+  print('Instances,' + s_round(total_files, 0))
+  print('All jobs solutions,' + s_round(job_ok_files, 0) + ',' + s_round(100 * float(job_ok_files) / total_files, 2) + '%')
+  print('Optimal solutions,' + s_round(optimal_sols, 0) + ',' + s_round(100 * float(optimal_sols) / total_files, 2) + '%')
 
   # Percentiles
-  print ','
+  print(',')
   gaps_percentiles = np.percentile(gaps, [0, 10, 25, 50, 75, 90, 100])
   ct_percentiles = np.percentile(computing_times, [0, 10, 25, 50, 75, 90, 100])
-  print ',Gaps,Computing times'
+  print(',Gaps,Computing times')
   titles = ['Min', 'First decile', 'Lower quartile', 'Median', 'Upper quartile', 'Ninth decile', 'Max']
   for i in range(len(titles)):
-    print titles[i] + ',' + s_round(gaps_percentiles[i], 2) + ',' + s_round(ct_percentiles[i], 0)
+    print(titles[i] + ',' + s_round(gaps_percentiles[i], 2) + ',' + s_round(ct_percentiles[i], 0))
 
 if __name__ == "__main__":
   # First argument if the best known solution file.

--- a/src/add_osrm_matrix.py
+++ b/src/add_osrm_matrix.py
@@ -51,6 +51,6 @@ if __name__ == "__main__":
     data['matrix'].append(map(lambda d: round_to_cost(d), line))
 
   with open(output_name, 'w') as out:
-    print 'Writing problem with matrix to ' + output_name
+    print('Writing problem with matrix to ' + output_name)
     json.dump(data, out, indent = 2)
 

--- a/src/cvrplib_to_json.py
+++ b/src/cvrplib_to_json.py
@@ -38,7 +38,7 @@ def parse_cvrp(input_file):
   meta['CAPACITY'] = int(meta['CAPACITY'])
 
   # Find start of nodes descriptions.
-  node_start = (i for i, s in enumerate(lines) if s.startswith('NODE_COORD_SECTION')).next()
+  node_start = next((i for i, s in enumerate(lines) if s.startswith('NODE_COORD_SECTION')))
 
   # Defining all jobs.
   jobs = []
@@ -62,7 +62,7 @@ def parse_cvrp(input_file):
 
   # Add all job demands.
   total_demand = 0
-  demand_start = (i for i, s in enumerate(lines) if s.startswith('DEMAND_SECTION')).next()
+  demand_start = next((i for i, s in enumerate(lines) if s.startswith('DEMAND_SECTION')))
   for i in range(demand_start + 1, demand_start + 1 + meta['DIMENSION']):
     demand_line = parse_node_coords(lines[i])
 
@@ -81,7 +81,7 @@ def parse_cvrp(input_file):
         break
 
   # Find depot description.
-  depot_start = (i for i, s in enumerate(lines) if s.startswith('DEPOT_SECTION')).next()
+  depot_start = next((i for i, s in enumerate(lines) if s.startswith('DEPOT_SECTION')))
 
   depot_def = lines[depot_start + 1].strip().split(' ')
   if len(depot_def) == 2:
@@ -94,7 +94,7 @@ def parse_cvrp(input_file):
     # Depot is one of the existing jobs, we retrieve loc and index in
     # coords, then remove the job.
     depot_id = int(depot_def[0])
-    job_index =  (i for i, j in enumerate(jobs) if j['id'] == depot_id).next()
+    job_index =  next((i for i, j in enumerate(jobs) if j['id'] == depot_id))
     depot_loc = jobs[job_index]['location']
     depot_index = jobs[job_index]['location_index']
     jobs.pop(job_index)
@@ -105,7 +105,7 @@ def parse_cvrp(input_file):
     meta['VEHICLES'] = int(meta['VEHICLES'])
     nb_vehicles = meta['VEHICLES']
   else:
-    nb_vehicles = 1 + (total_demand / meta['CAPACITY'])
+    nb_vehicles = int(1 + (total_demand / meta['CAPACITY']))
 
   vehicles = []
 

--- a/src/cvrplib_to_json.py
+++ b/src/cvrplib_to_json.py
@@ -31,7 +31,7 @@ def parse_cvrp(input_file):
       message += ': ' + meta['EDGE_WEIGHT_TYPE']
     message += '.'
 
-    print message
+    print(message)
     exit(0)
 
   meta['DIMENSION'] = int(meta['DIMENSION'])
@@ -125,7 +125,7 @@ if __name__ == "__main__":
   input_file = sys.argv[1]
   output_name = input_file[:input_file.rfind('.vrp')] + '.json'
 
-  print '- Writing problem ' + input_file + ' to ' + output_name
+  print('- Writing problem ' + input_file + ' to ' + output_name)
   json_input = parse_cvrp(input_file)
 
   with open(output_name, 'w') as out:

--- a/src/global_indicators.py
+++ b/src/global_indicators.py
@@ -42,10 +42,10 @@ if __name__ == "__main__":
   r = global_indicators(map(lambda f: os.path.join(sys.argv[1], f),
                             os.listdir(folder)))
 
-  print folder
-  print r
+  print(folder)
+  print(r)
 
   # CSV values
   size = folder[:folder.find('/')]
   s = ','
-  print size, s, r['computing_times']['loading'], s, r['computing_times']['solving'], s, r['computing_times']['routing'], s
+  print(size, s, r['computing_times']['loading'], s, r['computing_times']['solving'], s, r['computing_times']['routing'], s)

--- a/src/overpass_to_json.py
+++ b/src/overpass_to_json.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
                                  [args.right, args.top]])['elements']
 
   if len(nodes) < 2:
-    print "Too few nodes to format a problem!"
+    print("Too few nodes to format a problem!")
     sys.exit(0)
 
   lons = map(lambda n: n['lon'], nodes)

--- a/src/plot.py
+++ b/src/plot.py
@@ -8,7 +8,7 @@ import matplotlib.colors as clrs
 def plot_routes(sol_file_name):
   plot_file_name = sol_file_name[0:sol_file_name.rfind(".json")] + ".svg"
 
-  print "Parsing " + sol_file_name
+  print("Parsing " + sol_file_name)
   with open(sol_file_name, 'r') as sol_file:
     solution = json.load(sol_file)
 
@@ -89,7 +89,7 @@ def plot_routes(sol_file_name):
   ax1.set_ylim(ymin - margin_delta, ymax + margin_delta)
   ax1.set_aspect('equal')
 
-  print "Plotting file " + plot_file_name
+  print("Plotting file " + plot_file_name)
   plt.savefig(plot_file_name, bbox_inches='tight')
   plt.close()
   # plt.show()

--- a/src/tsplib_to_json.py
+++ b/src/tsplib_to_json.py
@@ -30,7 +30,7 @@ def parse_tsp(input_file):
   meta['DIMENSION'] = int(meta['DIMENSION'])
 
   # Find start of nodes descriptions.
-  node_start = (i for i, s in enumerate(lines) if s.startswith('NODE_COORD_SECTION')).next()
+  node_start = next((i for i, s in enumerate(lines) if s.startswith('NODE_COORD_SECTION')))
 
   # Use first line as vehicle start/end.
   coord_line = parse_node_coords(lines[node_start + 1])

--- a/src/tsplib_to_json.py
+++ b/src/tsplib_to_json.py
@@ -24,7 +24,7 @@ def parse_tsp(input_file):
 
   # Only support EUC_2D for now.
   if ('EDGE_WEIGHT_TYPE' not in meta) or (meta['EDGE_WEIGHT_TYPE'] != 'EUC_2D'):
-    print '  - Unsupported EDGE_WEIGHT_TYPE: ' + meta['EDGE_WEIGHT_TYPE'] + '.'
+    print('  - Unsupported EDGE_WEIGHT_TYPE: ' + meta['EDGE_WEIGHT_TYPE'] + '.')
     exit(0)
 
   meta['DIMENSION'] = int(meta['DIMENSION'])
@@ -66,7 +66,7 @@ if __name__ == "__main__":
   input_file = sys.argv[1]
   output_name = input_file[:input_file.rfind('.tsp')] + '.json'
 
-  print '- Writing problem ' + input_file + ' to ' + output_name
+  print('- Writing problem ' + input_file + ' to ' + output_name)
   json_input = parse_tsp(input_file)
 
   with open(output_name, 'w') as out:

--- a/src/utils/benchmark.py
+++ b/src/utils/benchmark.py
@@ -14,12 +14,12 @@ def euc_2D(c1, c2, PRECISION = 1):
 def get_value(key, lines):
   result = None
 
-  match = filter(lambda s: (s).startswith(key + ':'), lines)
+  match = list(filter(lambda s: (s).startswith(key + ':'), lines))
   if len(match) > 0:
     result = match[0][len(key) + 1:].strip()
   else:
     # Also try with a space.
-    match = filter(lambda s: (s).startswith(key + ' :'), lines)
+    match = list(filter(lambda s: (s).startswith(key + ' :'), lines))
     if len(match) > 0:
       result = match[0][len(key) + 2:].strip()
 

--- a/src/utils/csv_stuff.py
+++ b/src/utils/csv_stuff.py
@@ -17,7 +17,7 @@ def write_to_csv(file_name, json_input):
   for job in json_input['jobs']:
     lines.append(coord_to_csv(job['location']))
 
-  print 'Writing csv file to ' + file_name + '.csv'
+  print('Writing csv file to ' + file_name + '.csv')
   with open(file_name + '.csv', 'w') as output_file:
     for l in lines:
       output_file.write(l)

--- a/src/utils/format_input.py
+++ b/src/utils/format_input.py
@@ -58,13 +58,13 @@ def write_files(file_name, lons, lats, names, geojson, csv):
   json_input = format_json_from_coordinates(lons, lats, names)
 
   with open(file_name + '.json', 'w') as out:
-    print 'Writing problem to ' + file_name + '.json'
+    print('Writing problem to ' + file_name + '.json')
     json.dump(json_input,
               out,
               indent = 2)
   if geojson:
     with open(file_name + '.geojson', 'w') as out:
-      print 'Writing geojson file to ' + file_name + '.geojson'
+      print('Writing geojson file to ' + file_name + '.geojson')
       json.dump(format_geojson_from_coordinates(lons, lats, names), out, indent = 2)
 
   if csv:

--- a/src/vrptw_to_json.py
+++ b/src/vrptw_to_json.py
@@ -30,7 +30,7 @@ def parse_meta(lines, meta):
     else:
       x = l.split()
       if len(x) < 2:
-        print "Cannot understand line " + str(line_no) + ": too few columns."
+        print("Cannot understand line " + str(line_no) + ": too few columns.")
         exit(2)
       meta['VEHICLES'] = int(x[0]);
       meta['CAPACITY'] = int(x[1]);
@@ -48,7 +48,7 @@ def parse_jobs(lines, jobs, coords):
     else:
       x = l.split()
       if len(x) < 7:
-        print "Cannot understand line " + str(line_no) + ": too few columns."
+        print("Cannot understand line " + str(line_no) + ": too few columns.")
         exit(2)
       #some guys use '999' entry as terminator sign and others don't
       elif '999' in x[0] and len(jobs) < 999:
@@ -143,7 +143,7 @@ if __name__ == "__main__":
   input_file = sys.argv[1]
   output_name = input_file[:input_file.rfind('.txt')] + '.json'
 
-  print '- Writing problem ' + input_file + ' to ' + output_name
+  print('- Writing problem ' + input_file + ' to ' + output_name)
   json_input = parse_vrptw(input_file)
 
   with open(output_name, 'w') as out:


### PR DESCRIPTION
On my computer the `python` binary is python 3. Replacing print statements with print-function calls make these scripts run with python 3 and python 2 for me.

/edit:

Added another commit that makes the CVPR and TSP scripts compatible