### PR TITLE
Pass input to vroom via stdin rather than argv to allow for larger sized input

### DIFF
--- a/src/utils/vroom.py
+++ b/src/utils/vroom.py
@@ -7,9 +7,8 @@ import subprocess
 def solve(data, cl_args):
     args = ["vroom"]
     args.extend(cl_args)
-    args.append(json.dumps(data))
     try:
-        result = subprocess.check_output(args)
+        result = subprocess.check_output(args, text=True, input=json.dumps(data))
     except subprocess.CalledProcessError as e:
         # Some error reported by vroom
         json_error = json.loads(e.output)


### PR DESCRIPTION
I ran into an issue with large input causing the following error:
```
OSError: [Errno 7] Argument list too long: ‘vroom’
```

STDIN doesn't have a size restriction and using it allows for passing larger sized inputs to Vroom.